### PR TITLE
Fix mavlink2rest bugs

### DIFF
--- a/dvl-a50/mavlink2resthelper.py
+++ b/dvl-a50/mavlink2resthelper.py
@@ -15,7 +15,10 @@ class Mavlink2RestHelper:
     Responsible for interfacing with Mavlink2Rest
     """
 
-    def __init__(self):
+    def __init__(self, vehicle: int=1, component: int=1):
+        # store vehicle and component to access telemetry data from
+        self.vehicle = vehicle
+        self.component = component
         # store vision template data so we don't need to fetch it multiple times
         self.start_time = time.time()
         self.vision_template = """
@@ -166,24 +169,29 @@ class Mavlink2RestHelper:
 }}
 """
 
-    def get_float(self, path: str) -> float:
+    def get_float(self, path: str, vehicle: int=None, component: int=None) -> float:
         """
-        Helper to get mavlink data from mavlink2rest
+        Helper to get mavlink data from mavlink2rest.
+        Uses initialised vehicle and component as defaults, unless overridden.
         Example: get_float('/VFR_HUD')
-        Returns the data as a float or False on failure
+        Returns the data as a float (nan on failure)
         """
-        response = request(MAVLINK2REST_URL + '/mavlink' + path)
+        response = self.get(path, vehicle, component)
         if not response:
             return float("nan")
         return float(response)
 
-    def get(self, path: str) -> str:
+    def get(self, path: str, vehicle: int=None, component: int=None) -> str:
         """
         Helper to get mavlink data from mavlink2rest
+        Uses initialised vehicle and component as defaults, unless overridden.
         Example: get('/VFR_HUD')
         Returns the data as text or False on failure
         """
-        response = request(MAVLINK2REST_URL + '/mavlink' + path)
+        vehicle = vehicle or self.vehicle
+        component = component or self.component
+        vehicle_path = f"/vehicles/{vehicle}/components/{component}/messages"
+        response = request(MAVLINK2REST_URL + '/mavlink' + vehicle_path + path)
         if not response:
             return False
         return response

--- a/dvl-a50/mavlink2resthelper.py
+++ b/dvl-a50/mavlink2resthelper.py
@@ -1,4 +1,4 @@
-from companionhelper import request, post
+from blueoshelper import request, post
 import requests
 import json
 import time

--- a/dvl-a50/static/service.json
+++ b/dvl-a50/static/service.json
@@ -4,6 +4,6 @@
     "icon":"mdi-clock-fast",
     "company":"Blue Robotics",
     "version":"1.0.0",
-    "webpage":"https://github.com/williangalvani/companion-dvl",
+    "webpage":"https://github.com/bluerobotics/BlueOS-Water-Linked-DVL",
     "api":""
  }


### PR DESCRIPTION
- Fixes #5 
- Vehicle and component specifiers aren't properly accessible - need some rework of `dvl.py`, `main.py`, and front end
- May also be worth incrementing version number - not sure if it's best to use `1.0.1` or `1.1.0`