### PR TITLE
Try to fix bad attitude - untested

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ profile = "black"
         "suppressed-message",
         "too-few-public-methods", # We know what kind of architecture we want
         "too-many-public-methods", # Wrappers will have multiple public methods
+        "too-many-locals",
         "useless-super-delegation", # Fails to check it properly
         "wildcard-import", # Necessary to locate installed plugins
         "wrong-import-position",


### PR DESCRIPTION
A bit of work towards #18 - untested.

Feel free to fork or cherry-pick as relevant. I'm not fully confident that the `attitude_delta` is correct for the `DVL_FORWARD` case, and it's possible there'll be some weirdness from the attitude lag since the DVL expects to send dead reckoning reports at 5 Hz, which gives a max delay of ~200 ms.

It seems like [the WL interface](https://waterlinked.github.io/dvl/gui/dashboard/) provides access to the dead reckoning reset and gyro calibration functionalities, so they should be accessible via the iframe and don't need to be re-implemented via the API and extension interface.