### PR TITLE
Improve port assignment for safety

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,19 @@ RUN cd /home/pi/dvl-a50 && pip3 install .
 LABEL version="1.0.3"
 LABEL permissions='\
 {\
-    "NetworkMode": "host"\
+ "ExposedPorts": {\
+   "9001/tcp": {}\
+  },\
+  "HostConfig": {\
+    "Binds":["/root/.config:/root/.config"],\
+    "PortBindings": {\
+      "9001/tcp": [\
+        {\
+          "HostPort": ""\
+        }\
+      ]\
+    }\
+  }\
 }'
 LABEL authors='[\
     {\

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ## Changelog
 
+### v1.0.3
+ - Uses an random available port instead of 9001 to avoid conflict
+ - Updated menu icon
+
 ### v1.0.2
  - Improved style
 

--- a/dvl-a50/static/service.json
+++ b/dvl-a50/static/service.json
@@ -1,9 +1,9 @@
 {
     "name":"DVL A50",
     "description":"Driver for Waterlinked's DVL A50",
-    "icon":"mdi-clock-fast",
+    "icon":"mdi-dots-vertical",
     "company":"Blue Robotics",
-    "version":"1.0.1",
+    "version":"1.0.3",
     "webpage":"https://github.com/bluerobotics/BlueOS-Water-Linked-DVL",
     "api":""
  }


### PR DESCRIPTION
Update Dockerfile permissions to bind the service's port to a random available port rather than 9001 to avoid conflict with other services that might use 9001.

Also update the menu icon logo. :-)