### PR TITLE
Allow using `SPEED_ESTIMATE` messages

### DIFF
--- a/dvl-a50/dvl.py
+++ b/dvl-a50/dvl.py
@@ -382,7 +382,11 @@ class DvlDriver(threading.Thread):
             self.mav.send_vision(position_delta, attitude_delta, dt=data["time"] * 1e3, confidence=confidence)
         elif self.should_send == MessageType.SPEED_ESTIMATE:
             velocity = [vx, vy, vz] if self.current_orientation == DVL_DOWN else [vz, vy, -vx]  # DVL_FORWARD
-            self.mav.send_vision_speed_estimate(velocity)
+            covariance = data.get("covariance")  # covariance was not provided in old protocol versions
+            if covariance is not None:
+                covariance = [element for row in covariance for element in row]  # Flatten 3x3 to 9 elements
+
+            self.mav.send_vision_speed_estimate(velocity, covariance, reset_counter=self.reset_counter)
 
         self.last_attitude = self.current_attitude
 

--- a/dvl-a50/mavlink2resthelper.py
+++ b/dvl-a50/mavlink2resthelper.py
@@ -123,7 +123,7 @@ class Mavlink2RestHelper:
     "max_distance": 5000,
     "current_distance": {0},
     "mavtype": {{
-      "type": "MAV_DISTANCE_SENSOR_LASER"
+      "type": "MAV_DISTANCE_SENSOR_ULTRASOUND"
     }},
     "id": 0,
     "orientation": {{

--- a/dvl-a50/mavlink2resthelper.py
+++ b/dvl-a50/mavlink2resthelper.py
@@ -121,13 +121,13 @@ class Mavlink2RestHelper:
     "time_boot_ms": 0,
     "min_distance": 0,
     "max_distance": 5000,
-    "current_distance": {0},
+    "current_distance": {distance},
     "mavtype": {{
       "type": "MAV_DISTANCE_SENSOR_ULTRASOUND"
     }},
     "id": 0,
     "orientation": {{
-      "type": "MAV_SENSOR_ROTATION_PITCH_270"
+      "type": "{orientation}"
     }},
     "covariance": 0,
     "horizontal_fov": 0.0,
@@ -329,11 +329,11 @@ class Mavlink2RestHelper:
         )
         logger.info(post(MAVLINK2REST_URL + "/mavlink", data=data))
 
-    def send_rangefinder(self, distance: float):
+    def send_rangefinder(self, distance: float, orientation: str):
         "Sends message common.DISTANCE_SENSOR to flight controller"
         if distance == -1:
             return
-        data = self.rangefinder_template.format(int(distance * 100))
+        data = self.rangefinder_template.format(distance=int(distance * 100), orientation=orientation)
 
         post(MAVLINK2REST_URL + "/mavlink", data=data)
 

--- a/dvl-a50/mavlink2resthelper.py
+++ b/dvl-a50/mavlink2resthelper.py
@@ -65,18 +65,8 @@ class Mavlink2RestHelper:
     "x": {vx},
     "y": {vy},
     "z": {vz},
-    "covariance": [
-      0.0,
-      0.0,
-      0.0,
-      0.0,
-      0.0,
-      0.0,
-      0.0,
-      0.0,
-      0.0
-    ],
-    "reset_counter": 0
+    "covariance": {covariance},
+    "reset_counter": {reset_counter}
   }}
 }}"""
 
@@ -96,29 +86,7 @@ class Mavlink2RestHelper:
     "roll": {roll},
     "pitch": {pitch},
     "yaw": {yaw},
-    "covariance": [
-      0.0,
-      0.0,
-      0.0,
-      0.0,
-      0.0,
-      0.0,
-      0.0,
-      0.0,
-      0.0,
-      0.0,
-      0.0,
-      0.0,
-      0.0,
-      0.0,
-      0.0,
-      0.0,
-      0.0,
-      0.0,
-      0.0,
-      0.0,
-      0.0
-    ],
+    "covariance": {covariance},
     "reset_counter": {reset_counter}
   }}
 }}"""
@@ -311,7 +279,7 @@ class Mavlink2RestHelper:
             return False
 
     def send_vision(self, position_deltas, rotation_deltas=(0, 0, 0), confidence=100, dt=125000):
-        "Sends message VISION_POSITION_DELTA to flight controller"
+        "Sends message ardupilotmega.VISION_POSITION_DELTA to flight controller"
         data = self.vision_template.format(
             dt=int(dt),
             dRoll=radians(rotation_deltas[0]),
@@ -325,21 +293,29 @@ class Mavlink2RestHelper:
 
         post(MAVLINK2REST_URL + "/mavlink", data=data)
 
-    def send_vision_speed_estimate(self, speed_estimates):
-        "Sends message VISION_SPEED_ESTIMATE to flight controller"
+    def send_vision_speed_estimate(self, speed_estimates, covariance=None, reset_counter=0):
+        "Sends message common.VISION_SPEED_ESTIMATE to flight controller"
+        if covariance is None:
+            covariance = [float("NaN"), *[0.0] * 8]  # NaN first element means unknown
+
         data = self.vision_speed_estimate_template.format(
             us=int((time.time() - self.start_time) * 1e6),
             vx=speed_estimates[0],
             vy=speed_estimates[1],
             vz=speed_estimates[2],
+            covariance=covariance,
+            reset_counter=reset_counter,
         )
 
         post(MAVLINK2REST_URL + "/mavlink", data=data)
 
     def send_vision_position_estimate(
-        self, timestamp, position_estimates, attitude_estimates=(0.0, 0.0, 0.0), reset_counter=0
+        self, timestamp, position_estimates, attitude_estimates=(0.0, 0.0, 0.0), covariance=None, reset_counter=0
     ):
-        "Sends message GLOBAL_VISION_POSITION_ESTIMATE to flight controller"
+        "Sends message common.GLOBAL_VISION_POSITION_ESTIMATE to flight controller"
+        if covariance is None:
+            covariance = [float("NaN"), *[0.0] * 20]  # NaN first element means unknown
+
         data = self.global_vision_position_estimate_template.format(
             us=int(timestamp * 1e3),
             roll=radians(attitude_estimates[0]),
@@ -348,12 +324,13 @@ class Mavlink2RestHelper:
             x=position_estimates[0],
             y=position_estimates[1],
             z=position_estimates[2],
+            covariance=covariance,
             reset_counter=reset_counter,
         )
         logger.info(post(MAVLINK2REST_URL + "/mavlink", data=data))
 
     def send_rangefinder(self, distance: float):
-        "Sends message DISTANCE_SENSOR to flight controller"
+        "Sends message common.DISTANCE_SENSOR to flight controller"
         if distance == -1:
             return
         data = self.rangefinder_template.format(int(distance * 100))

--- a/dvl-a50/static/index.html
+++ b/dvl-a50/static/index.html
@@ -143,7 +143,7 @@
 						this.enabled = data.enabled
 						this.orientation = data.orientation
 						this.origin = data.origin
-						if (this.newOrigin === ['0','0']) {
+						if (this.newOrigin == ['0','0']) {
 							this.newOrigin = data.origin
 						}
 						this.rangefinder = data.rangefinder

--- a/dvl-a50/static/index.html
+++ b/dvl-a50/static/index.html
@@ -58,8 +58,6 @@
 							</v-radio-group>
 						</v-card>
 					</v-col>
-					<!-- uncoomment this to allow pointing the dvl forward-->
-					<!--
 					<v-col>
 						<v-card height="200">
 							<h2>Orientation:</h2>
@@ -69,7 +67,6 @@
 						</v-card>
 					</v-col>
 					<v-col>
-					-->
 					<v-col
 					class="col-12 col-sm-6 col-md-8">
 						<v-card height="650">

--- a/dvl-a50/static/index.html
+++ b/dvl-a50/static/index.html
@@ -49,8 +49,6 @@
 							</div>
 						</v-card>
 					</v-col>
-					<!-- uncoomment this to have control of what kind of message is bein sent and to allow pointing the dvl forward-->
-					<!--
 					<v-col>
 						<v-card height="200">
 							<h2>Message type:</h2>
@@ -60,6 +58,8 @@
 							</v-radio-group>
 						</v-card>
 					</v-col>
+					<!-- uncoomment this to allow pointing the dvl forward-->
+					<!--
 					<v-col>
 						<v-card height="200">
 							<h2>Orientation:</h2>
@@ -126,7 +126,7 @@
 				rovMarker: undefined,
 				newHostname: null,
 				rovPosition: [],
-				messageOptions: ["POSITION_DELTA", "POSITION_ESTIMATE", "SPEED_ESTIMATE"],
+				messageOptions: ["POSITION_DELTA", "SPEED_ESTIMATE", "POSITION_ESTIMATE"],
 				orientationOptions: {
 					"Downwards (LED pointing forward)": 1,
 					"Forward (Experimental)": 2,


### PR DESCRIPTION
`SPEED_ESTIMATE` [was previously disallowed](https://github.com/bluerobotics/BlueOS-Water-Linked-DVL/issues/18#issuecomment-1261667216) because MAVLink2REST didn't support `NaN` values, but that [has been resolved](https://github.com/mavlink/mavlink2rest/releases/tag/t0.11.9), and should be fixed in BlueOS [since `1.1.0`](https://github.com/bluerobotics/BlueOS/pull/1295), which is far enough behind latest stable (`1.2.5`) that it seems reasonable to assume people have updated, especially if they're wanting to update to a new Extension version.

This PR:
1. Un-hides the frontend message type switching
1. Implements "unknown" covariance defaults for the relevant MAVLink messages
1. Supports retrieving velocity covariance values from a WL-DVL that provides the field
    - ~The value order should be confirmed (MAVLink [specifies](https://mavlink.io/en/messages/common.html#VISION_SPEED_ESTIMATE) row-major order, where the first three values are `[vx, vy, vz; ...]`, but [the WL protocol docs do not specify](https://waterlinked.github.io/dvl/dvl-protocol/#velocity-report-wrz)~
        - **EDIT:** WL have fairly pointed out that covariance matrices are symmetric, so this shouldn't be relevant (although I am still a bit miffed as to why MAVLink specifies an order and all 9 terms, when the position covariance matrices are specified with only the upper right triangle...)
1. Fixes a code case the IDE was complaining was unreachable because 
    > This condition will always return 'false' since JavaScript compares objects by reference, not value.
    - ⚠️ I'm insufficiently confident with my javascript and the context of the relevant code to know whether that warning was correct - the commit can be removed if the code was ok as-is
1. Corrects the rangefinder type, as ultrasonic instead of laser-based
1. Enabled support for operating the DVL in forward orientation
     - ⚠️ possibly worth checking the velocity covariance matrix ordering/negations
     - ⚠️ ⚠️ did not add handling support to `handle_position_local` - I'm unsure what needs doing there, because I don't know whether the DVL's internal EKF accounts for the sensor's orientation in its position estimates, which is what I've currently assumed (quite possibly incorrectly)