### PR TITLE
workflows: deploy.yml: don't try to auto-build for PRs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,6 @@ name: Deploy BlueOS Extension Image
 
 on:
   push:
-  pull_request:
   # Run manually
   workflow_dispatch:
   # NOTE: caches may be removed if not run weekly


### PR DESCRIPTION
Contributors can auto-build in their own forks, and PRs generally don't have access to GitHub secrets so PR building by the receiving repository doesn't work anyway.