### PR TITLE
Save the `origin` setting

### DIFF
--- a/dvl-a50/dvl.py
+++ b/dvl-a50/dvl.py
@@ -82,12 +82,12 @@ class DvlDriver(threading.Thread):
         try:
             with open(self.settings_path) as settings:
                 data = json.load(settings)
-                self.enabled = data["enabled"]
-                self.current_orientation = data["orientation"]
-                self.hostname = data["hostname"]
-                self.origin = data["origin"]
-                self.rangefinder = data["rangefinder"]
-                self.should_send = data["should_send"]
+                self.enabled = data.get("enabled", self.enabled)
+                self.current_orientation = data.get("orientation", self.orientation)
+                self.hostname = data.get("hostname", self.hostname)
+                self.origin = data.get("origin", self.origin)
+                self.rangefinder = data.get("rangefinder", self.rangefinder)
+                self.should_send = data.get("should_send", self.should_send)
                 logger.debug("Loaded settings: ", data)
         except FileNotFoundError:
             logger.warning("Settings file not found, using default.")

--- a/dvl-a50/dvl.py
+++ b/dvl-a50/dvl.py
@@ -118,6 +118,7 @@ class DvlDriver(threading.Thread):
                         "enabled": self.enabled,
                         "orientation": self.current_orientation,
                         "hostname": self.hostname,
+                        "origin": self.origin,
                         "rangefinder": self.rangefinder,
                         "should_send": self.should_send,
                     }


### PR DESCRIPTION
While trying out v1.0.9, we noticed that the extension wasn't able to load its settings. It looks like we are trying to load `origin` from the settings, but `save_settings()` never saves it. 

I'm guessing this has always been a bug, and d5bf837af32cc9057c24b4c35cd90a3548a50cf2 just means we save configs more often.

I've also switched from using `self.enabled = data["enabled"]` to using `self.enabled = data.get("enabled", self.enabled)` so it will fall back to using `self.enabled` if the `"enabled"` key isn't set.