### PR TITLE
Add support for individual beam distance sensors and test mode

### DIFF
--- a/dvl-a50/dvlfinder.py
+++ b/dvl-a50/dvlfinder.py
@@ -1,4 +1,5 @@
 import json
+import os
 import time
 from typing import List, Optional
 
@@ -25,6 +26,11 @@ def get_ips_wildcards(ips: List[str]):
 
 
 def find_the_dvl() -> Optional[str]:
+    # Skip DVL scanning if running in test mode
+    if os.environ.get("DVL_TEST_MODE", "false").lower() == "true":
+        logger.info("Running in test mode, skipping DVL network scan")
+        return None
+        
     # The dvl always reports 192.168.194.95 on mdns, so we need to take drastic measures.
     # Nmap to the rescue!
 

--- a/dvl-a50/main.py
+++ b/dvl-a50/main.py
@@ -63,6 +63,14 @@ class API:
             return self.dvl.set_use_as_rangefinder(enabled == "true")
         return False
 
+    def set_beam_distances_enabled(self, enabled: str) -> bool:
+        """
+        Enables/disables individual beam distance sensors
+        """
+        if enabled in ["true", "false"]:
+            return self.dvl.set_beam_distances_enabled(enabled == "true")
+        return False
+
     def load_params(self, selector: str) -> bool:
         """
         Load parameters
@@ -90,6 +98,10 @@ if __name__ == "__main__":
     @app.route("/use_as_rangefinder/<enable>")
     def set_use_rangefinder(enable: str):
         return str(api.set_use_as_rangefinder(enable))
+
+    @app.route("/beam_distances/<enable>")
+    def set_beam_distances(enable: str):
+        return str(api.set_beam_distances_enabled(enable))
 
     @app.route("/load_params/<selector>")
     def load_params(selector: str):

--- a/dvl-a50/mavlink2resthelper.py
+++ b/dvl-a50/mavlink2resthelper.py
@@ -153,13 +153,13 @@ class Mavlink2RestHelper:
     "time_boot_ms": 0,
     "min_distance": 0,
     "max_distance": 5000,
-    "current_distance": {0},
+    "current_distance": {distance},
     "mavtype": {{
       "type": "MAV_DISTANCE_SENSOR_LASER"
     }},
-    "id": 0,
+    "id": {sensor_id},
     "orientation": {{
-      "type": "MAV_SENSOR_ROTATION_PITCH_270"
+      "type": "{orientation}"
     }},
     "covariance": 0,
     "horizontal_fov": 0.0,
@@ -352,13 +352,35 @@ class Mavlink2RestHelper:
         )
         logger.info(post(MAVLINK2REST_URL + "/mavlink", data=data))
 
-    def send_rangefinder(self, distance: float):
+    def send_rangefinder(self, distance: float, sensor_id: int = 0, orientation: str = "MAV_SENSOR_ROTATION_PITCH_270"):
         "Sends message DISTANCE_SENSOR to flight controller"
         if distance == -1:
             return
-        data = self.rangefinder_template.format(int(distance * 100))
-
+        data = self.rangefinder_template.format(
+            distance=int(distance * 100), 
+            sensor_id=sensor_id, 
+            orientation=orientation
+        )
         post(MAVLINK2REST_URL + "/mavlink", data=data)
+
+    def send_beam_distances(self, beam_distances: list, beam_valid: list):
+        """
+        Send individual beam distances from DVL transducers as separate DISTANCE_SENSOR messages
+        Each beam gets a different orientation to work around ArduSub's single rangefinder per orientation limitation
+        """
+        # Define orientations for each beam (1=rear-right, 2=rear-left, 3=front-left, 4=front-right)
+        # These orientations represent the 4 quadrants around the DVL
+        beam_orientations = [
+            "MAV_SENSOR_ROTATION_YAW_135",  # rear-right
+            "MAV_SENSOR_ROTATION_YAW_225",  # rear-left
+            "MAV_SENSOR_ROTATION_YAW_315",  # front-left 
+            "MAV_SENSOR_ROTATION_YAW_45"    # front-right
+        ]
+        
+        for i, (distance, valid) in enumerate(zip(beam_distances, beam_valid)):
+            if valid and distance > 0.05:  # Only send valid readings above 5cm
+                # Use sensor_id 1-4 for individual beams (0 is reserved for average)
+                self.send_rangefinder(distance, sensor_id=i+1, orientation=beam_orientations[i])
 
     def set_gps_origin(self, lat, lon):
         data = self.gps_origin_template.format(lat=int(float(lat) * 1e7), lon=int(float(lon) * 1e7))

--- a/dvl-a50/static/index.html
+++ b/dvl-a50/static/index.html
@@ -42,12 +42,64 @@
 							<h2>Settings</h2>
 							<v-switch v-model="this.enabled" inset :label="`Enable DVL driver`" @change="setDvlEnabled($event)"></v-switch>
 							<v-switch v-model="this.rangefinder" inset :label="`Send range data through MAVLink`" @change="setDvlAsRangefinder($event)"></v-switch>
+							<v-switch v-model="this.beamDistancesEnabled" inset :label="`Send individual beam distances`" @change="setBeamDistancesEnabled($event)"></v-switch>
 							<v-btn id="btn-load-dvl" type="button" class="btn btn-primary" @click="loadParams('dvl');">Load parameters for DVL</v-btn>
 							<v-btn id="btn-load-dvl-gps" type="button" class="btn btn-primary" @click="loadParams('dvl_gps');">Load parameters for DVL+GPS</v-btn>
 							<h2>Status</h2>
 							<div>
 								<textarea readonly style="width:100%;"
 									id="dvl-status"> {{status}} </textarea>
+							</div>
+						</v-card>
+					</v-col>
+					<v-col>
+						<v-card height="650">
+							<h2>Distance Sensors</h2>
+							<div style="padding: 20px;">
+								<h3>Average Altitude</h3>
+								<div style="font-size: 24px; color: #1976d2; margin-bottom: 20px;">
+									{{ rangefinder ? 'Enabled' : 'Disabled' }}
+								</div>
+								
+								<h3>Individual Beam Distances</h3>
+								<div style="margin-bottom: 10px;">
+									Status: {{ beamDistancesEnabled ? 'Enabled' : 'Disabled' }}
+								</div>
+								
+								<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-top: 15px;">
+									<div style="border: 1px solid #ccc; padding: 10px; text-align: center;">
+										<div style="font-weight: bold;">Beam 3 (Front-Left)</div>
+										<div style="font-size: 18px;" :style="{ color: beamValid[0] ? '#4caf50' : '#f44336' }">
+											{{ beamValid[2] ? (beamDistances[2]).toFixed(2) + ' m' : 'Invalid' }}
+										</div>
+									</div>
+									<div style="border: 1px solid #ccc; padding: 10px; text-align: center;">
+										<div style="font-weight: bold;">Beam 4 (Front-Right)</div>
+										<div style="font-size: 18px;" :style="{ color: beamValid[1] ? '#4caf50' : '#f44336' }">
+											{{ beamValid[3] ? (beamDistances[3]).toFixed(2) + ' m' : 'Invalid' }}
+										</div>
+									</div>
+									<div style="border: 1px solid #ccc; padding: 10px; text-align: center;">
+										<div style="font-weight: bold;">Beam 1 (Back-Right)</div>
+										<div style="font-size: 18px;" :style="{ color: beamValid[2] ? '#4caf50' : '#f44336' }">
+											{{ beamValid[0] ? (beamDistances[0]).toFixed(2) + ' m' : 'Invalid' }}
+										</div>
+									</div>
+									<div style="border: 1px solid #ccc; padding: 10px; text-align: center;">
+										<div style="font-weight: bold;">Beam 2 (Back-Left)</div>
+										<div style="font-size: 18px;" :style="{ color: beamValid[3] ? '#4caf50' : '#f44336' }">
+											{{ beamValid[1] ? (beamDistances[1]).toFixed(2) + ' m' : 'Invalid' }}
+										</div>
+									</div>
+								</div>
+								
+								<div style="margin-top: 20px; font-size: 12px; color: #666;">
+									<strong>Note:</strong> Each beam sends DISTANCE_SENSOR messages with different orientations:<br/>
+									• Beam 0: YAW_315° (Front-Left)<br/>
+									• Beam 1: YAW_45° (Front-Right)<br/>
+									• Beam 2: YAW_135° (Back-Right)<br/>
+									• Beam 3: YAW_225° (Back-Left)
+								</div>
 							</div>
 						</v-card>
 					</v-col>
@@ -133,7 +185,10 @@
 				orientationOptions: {
 					"Downwards (LED pointing forward)": 1,
 					"Forward (Experimental)": 2,
-				}
+				},
+				beamDistancesEnabled: false,
+				beamDistances: [0, 0, 0, 0],
+				beamValid: [false, false, false, false]
 			}
 		},
 		methods: {
@@ -156,6 +211,9 @@
 						if (this.newHostname == null) {
 							this.newHostname = data.hostname
 						}
+						this.beamDistancesEnabled = data.beam_distances_enabled
+						this.beamDistances = data.beam_distances
+						this.beamValid = data.beam_valid
 					})
 					.catch((error) => {
 						this.status = `Unable to talk to DVL service: ${error}`
@@ -284,6 +342,13 @@
 				request.open('GET', 'setcurrentposition/' + this.newLat + '/' + this.newLong, true);
 				request.send();
 			},
+
+			setBeamDistancesEnabled(value) {
+				const request = new XMLHttpRequest();
+				request.timeout = 800;
+				request.open('GET', 'beam_distances/' + value, true);
+				request.send();
+			}
 
 		},
 		mounted() {


### PR DESCRIPTION
This PR adds support for parsing, logging and displaying in the UI, the individual beam distances.

This work was completed to help support the Seattle Aquarium's ROV project (see relevant issue here: https://github.com/Seattle-Aquarium/CCR_development/issues/16).

Additional context on the use case is listed in this document: https://github.com/Seattle-Aquarium/CCR_development/blob/main/completed_1-pagers/DVL_beam_splitter.md

The new UI looks like the attached image below:

<img width="2482" height="1358" alt="image" src="https://github.com/user-attachments/assets/eaf3d8d3-3080-4436-b418-70dda5a595a2" />

Testing was completed at the Seattle aquarium with their ROV and an attached tlog file demonstrates the succesful logging of the additional distance sensor messages. In addition to the new distance sensor messages, I also added a "test  mode" enable that allows the extension to be run in a sim mode with the sim server from the water linked test server: dvl.demo.waterlinked.com:16171

